### PR TITLE
Add kgid_t data structure difference

### DIFF
--- a/scull/access.c
+++ b/scull/access.c
@@ -105,15 +105,15 @@ static int scull_u_open(struct inode *inode, struct file *filp)
 
 	spin_lock(&scull_u_lock);
 	if (scull_u_count && 
-			(scull_u_owner != current->cred->uid) &&  /* allow user */
-			(scull_u_owner != current->cred->euid) && /* allow whoever did su */
+			(scull_u_owner != current->cred->uid.val) &&  /* allow user */
+			(scull_u_owner != current->cred->euid.val) && /* allow whoever did su */
 			!capable(CAP_DAC_OVERRIDE)) { /* still allow root */
 		spin_unlock(&scull_u_lock);
 		return -EBUSY;   /* -EPERM would confuse the user */
 	}
 
 	if (scull_u_count == 0)
-		scull_u_owner = current->cred->uid; /* grab it */
+		scull_u_owner = current->cred->uid.val; /* grab it */
 
 	scull_u_count++;
 	spin_unlock(&scull_u_lock);
@@ -164,8 +164,8 @@ DEFINE_SPINLOCK(scull_w_lock);
 static inline int scull_w_available(void)
 {
 	return scull_w_count == 0 ||
-		scull_w_owner == current->cred->uid ||
-		scull_w_owner == current->cred->euid ||
+		scull_w_owner == current->cred->uid.val ||
+		scull_w_owner == current->cred->euid.val ||
 		capable(CAP_DAC_OVERRIDE);
 }
 
@@ -183,7 +183,7 @@ static int scull_w_open(struct inode *inode, struct file *filp)
 		spin_lock(&scull_w_lock);
 	}
 	if (scull_w_count == 0)
-		scull_w_owner = current->cred->uid; /* grab it */
+		scull_w_owner = current->cred->uid.val; /* grab it */
 	scull_w_count++;
 	spin_unlock(&scull_w_lock);
 


### PR DESCRIPTION
made changes in access.c to  address compile errors like the following one

/home/soccerl/src/ldd4/scull/access.c: In function ‘scull_u_open’:
/home/soccerl/src/ldd4/scull/access.c:108:19: error: invalid operands to binary != (have ‘uid_t {aka unsigned int}’ and ‘kuid_t {aka const struct <anonymous>}’)
    (scull_u_owner != current->cred->uid) &&  /\* allow user */
